### PR TITLE
fix: don't alert on 402 Payment Required errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ export async function sampleRetrieval({
     const reason = (await res.text()).trim()
     console.log(reason)
 
-    if (isSupportedSP) {
+    if (isSupportedSP && res.status !== 402) {
       console.error(
         'ALERT Cannot retrieve ProofSet %s Root %s (CID %s) from %s: %s %s',
         setId,


### PR DESCRIPTION
This is a quick stop-gap solution to stop false alerts.

See https://github.com/filcdn/worker/issues/41
