### PR TITLE
feat: withCDN:true sampling + deal client in URL

### DIFF
--- a/bin/bot.js
+++ b/bin/bot.js
@@ -1,12 +1,13 @@
 import { setTimeout } from 'node:timers/promises'
 import { ethers } from 'ethers'
-import { pdpVerifierAbi, sampleRetrieval } from '../index.js'
+import { pandoraServiceAbi, pdpVerifierAbi, sampleRetrieval } from '../index.js'
 
 const {
   GLIF_TOKEN,
   RPC_URL = 'https://api.calibration.node.glif.io/',
   PDP_VERIFIER_ADDRESS = '0x5A23b7df87f59A291C26A2A1d684AD03Ce9B68DC',
-  CDN_URL = 'https://0x000000000000000000000000000000000000dEaD.calibration.filcdn.io',
+  PANDORA_SERVICE_ADDRESS = '0xf49ba5eaCdFD5EE3744efEdf413791935FE4D4c5',
+  CDN_HOSTNAME = 'calibration.filcdn.io',
   DELAY = 1_000,
   FROM_PROOFSET_ID = 200,
 } = process.env
@@ -24,10 +25,16 @@ const pdpVerifier = /** @type {any} */ (
   new ethers.Contract(PDP_VERIFIER_ADDRESS, pdpVerifierAbi, provider)
 )
 
+/** @type {import('../index.js').PandoraService} */
+const pandoraService = /** @type {any} */ (
+  new ethers.Contract(PANDORA_SERVICE_ADDRESS, pandoraServiceAbi, provider)
+)
+
 while (true) {
   await sampleRetrieval({
     pdpVerifier,
-    CDN_URL,
+    pandoraService,
+    CDN_HOSTNAME,
     FROM_PROOFSET_ID: BigInt(FROM_PROOFSET_ID),
   })
   console.log('\n')


### PR DESCRIPTION
**Changes:**

- Modify the sampling algorithm to fetch Pandora Service deal linked to the selected ProofSet and skip ProofSets not paying for CDN.

- Modify the code building the CDN retrieval URL to use the client wallet address of the deal payer.

- Improve the speed of the sampling algorithm by caching the results of `getNextProofSetId()`, `proofSetLive()` and `getProofSet()` queries.

**Why is this needed?**

At the moment, the bot always triggers 402 Payment Required error. That's not useful.

**Links:**

- https://github.com/filcdn/worker/issues/41

**Important ramifications of this change:**

1. The bot will impersonate the client paying for the deal, and the retrieval requests performed by the bot will consume egress allowance the client paid for.

   This is fine as long as we are not enforcing egress quotas. I added a sub-task to the following issue to remind us to deal with this aspect:
   https://github.com/filcdn/roadmap/issues/11

2. We don't discriminate real traffic of user retrievals from synthetic traffic created by our bot. As a result, the client stats in https://dashboard.filcdn.com may be less useful.