### PR TITLE
feat: include retrieval URL in the alert message

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,11 +111,11 @@ export async function sampleRetrieval({
 
     if (isSupportedSP) {
       console.error(
-        'ALERT Cannot retrieve ProofSet %s Root %s (CID %s) from %s: %s %s',
-        setId,
-        rootId,
-        rootCid,
+        'ALERT Cannot retrieve ProofSet %s Root %s SP %s via %s: %s %s',
+        String(setId),
+        String(rootId),
         URL.parse(ownerUrl)?.hostname ?? ownerUrl,
+        url,
         res.status,
         reason,
       )


### PR DESCRIPTION
The goal is to include the client wallet address in the message. By printing the URL, we make it easier to quickly reproduce the problem.

This is a follow-up for #10
