### PR TITLE
feat: ignore ProofSet=442 CommP=baga(...)6maiwt6ay

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import { OWNER_TO_RETRIEVAL_URL_MAPPING } from './vendored/retriever-constants.j
 const IGNORED_ROOTS = [
   '212:baga6ea4seaqjlh5gvyf4v4nuwige3nynttmus2kxgr4s6c6rf2pjfkr5cu4rgci',
   '339:baga6ea4seaqnx4gnoeuqjyu7ctmhqtow4nnzukdfuyw3wr5bm73o5vlvbl5mgny',
+  '442:baga6ea4seaqnbpfza3wl5fgu7gnfcyh5h6zufn4skwt6clylnzaw5k6maiwt6ay',
 ]
 
 export const pdpVerifierAbi = [


### PR DESCRIPTION
Silence the following alert that's regularly triggered now:

```
Cannot retrieve ProofSet 442 Root 0 SP polynomial.computer via https://0xCe340D9A71b2aa8F7FAa2f989158f14BEDE3E1b2.calibration.filcdn.io/baga6ea4seaqnbpfza3wl5fgu7gnfcyh5h6zufn4skwt6clylnzaw5k6maiwt6ay: 404
Storage Provider (PDP ProofSet Provider) not found: 0x12191de399b9b3ffeb562861f9ed62ea8da18ae5
```
