### PR TITLE
feat: scripts to inspect on-chain state

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,13 @@ export const pandoraServiceAbi = [
     uint256 registeredAt,
     uint256 approvedAt,
   ) memory)`,
+  `function getAllApprovedProviders() external view returns (tuple(
+    address owner,
+    string pdpUrl,
+    string pieceRetrievalUrl,
+    uint256 registeredAt,
+    uint256 approvedAt,
+  )[] memory)`,
 ]
 
 /**
@@ -88,6 +95,7 @@ export const pandoraServiceAbi = [
  *   isProviderApproved(provider: string): Promise<boolean>
  *   getProviderIdByAddress(provider: string): Promise<BigInt>
  *   getApprovedProvider(providerId: BigInt): Promise<ApprovedProviderInfo>
+ *   getAllApprovedProviders(): Promise<ApprovedProviderInfo[]>
  * }} PandoraService
  */
 

--- a/inspect-proofset.js
+++ b/inspect-proofset.js
@@ -1,0 +1,51 @@
+import { ethers } from 'ethers'
+import assert from 'node:assert'
+import { pandoraServiceAbi } from './index.js'
+
+const {
+  GLIF_TOKEN,
+  RPC_URL = 'https://api.calibration.node.glif.io/',
+  PANDORA_SERVICE_ADDRESS = '0xf49ba5eaCdFD5EE3744efEdf413791935FE4D4c5',
+} = process.env
+
+const [proofSetIdString] = process.argv.slice(2)
+assert(proofSetIdString, 'Proof Set ID is required as the first argument')
+const proofSetId = BigInt(proofSetIdString)
+
+const fetchRequest = new ethers.FetchRequest(RPC_URL)
+if (GLIF_TOKEN) {
+  fetchRequest.setHeader('Authorization', `Bearer ${GLIF_TOKEN}`)
+}
+const provider = new ethers.JsonRpcProvider(fetchRequest, undefined, {
+  polling: true,
+})
+
+/** @type {import('../index.js').PandoraService} */
+const pandoraService = /** @type {any} */ (
+  new ethers.Contract(PANDORA_SERVICE_ADDRESS, pandoraServiceAbi, provider)
+)
+
+const proofSetInfo = await pandoraService.getProofSet(proofSetId)
+console.log('PROOF SET PANDORA INFO: %o', {
+  railId: proofSetInfo.railId,
+  payer: proofSetInfo.payer,
+  payee: proofSetInfo.payee,
+  commissionBps: proofSetInfo.commissionBps,
+  metadata: proofSetInfo.metadata,
+  // rootMetadata: proofSetInfo.rootMetadata,
+  clientDataSetId: proofSetInfo.clientDataSetId,
+  withCDN: proofSetInfo.withCDN,
+})
+
+const owner = proofSetInfo.payee
+console.log('OWNER ADDRESS: %s', owner)
+const providerId = await pandoraService.getProviderIdByAddress(owner)
+const providerInfo = await pandoraService.getApprovedProvider(providerId)
+
+console.log('PANDORA APPROVED PROVIDER INFO: %o', {
+  owner: providerInfo.owner,
+  pdpUrl: providerInfo.pdpUrl,
+  pieceRetrievalUrl: providerInfo.pieceRetrievalUrl,
+  registeredAt: providerInfo.registeredAt,
+  approvedAt: providerInfo.approvedAt,
+})

--- a/list-approved-providers.js
+++ b/list-approved-providers.js
@@ -1,0 +1,34 @@
+import { ethers } from 'ethers'
+import assert from 'node:assert'
+import { pandoraServiceAbi } from './index.js'
+
+const {
+  GLIF_TOKEN,
+  RPC_URL = 'https://api.calibration.node.glif.io/',
+  PANDORA_SERVICE_ADDRESS = '0xf49ba5eaCdFD5EE3744efEdf413791935FE4D4c5',
+} = process.env
+
+const fetchRequest = new ethers.FetchRequest(RPC_URL)
+if (GLIF_TOKEN) {
+  fetchRequest.setHeader('Authorization', `Bearer ${GLIF_TOKEN}`)
+}
+const provider = new ethers.JsonRpcProvider(fetchRequest, undefined, {
+  polling: true,
+})
+
+/** @type {import('../index.js').PandoraService} */
+const pandoraService = /** @type {any} */ (
+  new ethers.Contract(PANDORA_SERVICE_ADDRESS, pandoraServiceAbi, provider)
+)
+
+const providers = await pandoraService.getAllApprovedProviders()
+
+for (const providerInfo of providers) {
+  console.log('%o', {
+    owner: providerInfo.owner.toLowerCase(),
+    pdpUrl: providerInfo.pdpUrl,
+    pieceRetrievalUrl: providerInfo.pieceRetrievalUrl,
+    registeredAt: providerInfo.registeredAt,
+    approvedAt: providerInfo.approvedAt,
+  })
+}

--- a/list-approved-providers.js
+++ b/list-approved-providers.js
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers'
-import assert from 'node:assert'
 import { pandoraServiceAbi } from './index.js'
 
 const {


### PR DESCRIPTION
While troubleshooting failed retrievals caused by the retrieval worker not
ignoring providers not approved for Pandora, I wrote two scripts to inspect
on-chain state.

Let's discuss where would be a good home for them and in what form. (I can
imagine converting them into a static website hosted on GH pages.)

**feat: add `inspect-proofset` helper**

```
❯ node inspect-proofset.js 442
PROOF SET PANDORA INFO: {
  railId: 172n,
  payer: '0xCe340D9A71b2aa8F7FAa2f989158f14BEDE3E1b2',
  payee: '0xe9bc394383B67aBcEbe86FD9843F53d8B4a2E981',
  commissionBps: 4000n,
  metadata: '',
  clientDataSetId: 2n,
  withCDN: true
}
OWNER ADDRESS: 0xe9bc394383B67aBcEbe86FD9843F53d8B4a2E981
PANDORA APPROVED PROVIDER INFO: {
  owner: '0xe9bc394383B67aBcEbe86FD9843F53d8B4a2E981',
  pdpUrl: 'https://polynomial.computer/',
  pieceRetrievalUrl: 'https://polynomial.computer/',
  registeredAt: 2740187n,
  approvedAt: 2740187n
}
```

**feat: script to list approved providers**

```
❯ node list-approved-providers.js
{
  owner: '0xe9bc394383b67abcebe86fd9843f53d8b4a2e981',
  pdpUrl: 'https://polynomial.computer/',
  pieceRetrievalUrl: 'https://polynomial.computer/',
  registeredAt: 2740187n,
  approvedAt: 2740187n
}
{
  owner: '0x4a628ebaecc32b8779a934ebcefff1646f517756',
  pdpUrl: 'https://pdp.zapto.org/',
  pieceRetrievalUrl: 'https://pdp.zapto.org/',
  registeredAt: 2751328n,
  approvedAt: 2751328n
}
{
  owner: '0x9f5087a1821eb3ed8a137be368e5e451166efaae',
  pdpUrl: 'https://yablu.net',
  pieceRetrievalUrl: 'https://yablu.net',
  registeredAt: 2751328n,
  approvedAt: 2751328n
}
```
