### PR TITLE
Add test most recent retrievale root. Closes filcdn/roadmap#4

### DIFF
--- a/bin/bot.js
+++ b/bin/bot.js
@@ -1,6 +1,6 @@
 import { setTimeout } from 'node:timers/promises'
 import { ethers } from 'ethers'
-import { pandoraServiceAbi, pdpVerifierAbi, sampleRetrieval } from '../index.js'
+import { pandoraServiceAbi, pdpVerifierAbi, sampleRetrieval, testLatestRetrievableRoot } from '../index.js'
 
 const {
   GLIF_TOKEN,
@@ -30,13 +30,30 @@ const pandoraService = /** @type {any} */ (
   new ethers.Contract(PANDORA_SERVICE_ADDRESS, pandoraServiceAbi, provider)
 )
 
-while (true) {
-  await sampleRetrieval({
-    pdpVerifier,
-    pandoraService,
-    CDN_HOSTNAME,
-    FROM_PROOFSET_ID: BigInt(FROM_PROOFSET_ID),
-  })
-  console.log('\n')
-  await setTimeout(Number(DELAY))
-}
+await Promise.all([
+  (async () => {
+    while (true) {
+      await sampleRetrieval({
+        pdpVerifier,
+        pandoraService,
+        CDN_HOSTNAME,
+        FROM_PROOFSET_ID: BigInt(FROM_PROOFSET_ID),
+      })
+      console.log('\n')
+      await setTimeout(Number(DELAY))
+    }
+  })(),
+  (async () => {
+    while (true) {
+      await testLatestRetrievableRoot({
+        pdpVerifier,
+        pandoraService,
+        CDN_HOSTNAME
+      })
+      console.log('\n')
+      await setTimeout(Number(30_000)) // block time
+    }
+  })()
+])
+
+

--- a/bin/bot.js
+++ b/bin/bot.js
@@ -54,6 +54,7 @@ await Promise.all([
         pdpVerifier,
         pandoraService,
         CDN_HOSTNAME,
+        FROM_PROOFSET_ID: BigInt(FROM_PROOFSET_ID),
       })
       console.log('\n')
       await setTimeout(Number(30_000)) // block time

--- a/bin/bot.js
+++ b/bin/bot.js
@@ -1,6 +1,11 @@
 import { setTimeout } from 'node:timers/promises'
 import { ethers } from 'ethers'
-import { pandoraServiceAbi, pdpVerifierAbi, sampleRetrieval, testLatestRetrievableRoot } from '../index.js'
+import {
+  pandoraServiceAbi,
+  pdpVerifierAbi,
+  sampleRetrieval,
+  testLatestRetrievableRoot,
+} from '../index.js'
 
 const {
   GLIF_TOKEN,
@@ -48,12 +53,10 @@ await Promise.all([
       await testLatestRetrievableRoot({
         pdpVerifier,
         pandoraService,
-        CDN_HOSTNAME
+        CDN_HOSTNAME,
       })
       console.log('\n')
       await setTimeout(Number(30_000)) // block time
     }
-  })()
+  })(),
 ])
-
-

--- a/index.js
+++ b/index.js
@@ -354,3 +354,114 @@ async function pickRandomFileWithCDN({
     return { rootCid, setId, rootId, clientAddress }
   }
 }
+
+/**
+ * @param {object} args
+ * @param {PdpVerifier} args.pdpVerifier
+ * @param {PandoraService} args.pandoraService
+ * @param {string} args.CDN_HOSTNAME
+ */
+
+export async function testLatestRetrievableRoot({
+  pdpVerifier,
+  pandoraService,
+  CDN_HOSTNAME
+}) {
+  const { rootCid, proofSetId, rootId, clientAddress } = await getMostRecentFileWithCDN(
+    {
+      pdpVerifier,
+      pandoraService
+    },
+  )
+
+  await testRetrieval({
+    pdpVerifier,
+    pandoraService,
+    clientAddress,
+    CDN_HOSTNAME,
+    rootCid,
+    setId: proofSetId,
+    rootId,
+  })
+}
+
+/**
+ * @param {Object} args
+ * @param {PdpVerifier} args.pdpVerifier
+ * @param {PandoraService} args.pandoraService
+ * @returns {Promise<{
+ *   rootCid: string
+ *   proofSetId: BigInt
+ *   rootId: BigInt
+ *   clientAddress: string
+ * }>}
+ *   The CommP CID of the file.
+ */
+async function getMostRecentFileWithCDN({
+  pdpVerifier,
+  pandoraService
+}) {
+  for (
+    let proofSetId = (await pdpVerifier.getNextProofSetId()) - 1n;
+    proofSetId >= 0n;
+    proofSetId--
+  ) {
+    console.log('Checking proof set ID:', proofSetId)
+
+    const proofSetLive = await pdpVerifier.proofSetLive(proofSetId)
+    if (!proofSetLive) {
+      console.log('Proof set is not live')
+      continue
+    }
+
+    const info = await pandoraService.getProofSet(proofSetId)
+    const { withCDN, payer: clientAddress, payee: providerAddress } = info
+
+    if (!withCDN) {
+      console.log(
+        'Proof set does not pay for CDN',
+      )
+      continue
+    }
+
+    const providerIsApproved =
+      await pandoraService.isProviderApproved(providerAddress)
+    if (!providerIsApproved) {
+      console.log('Provider is not approved')
+      continue
+    }
+
+    console.log('Proofset client:', clientAddress)
+
+    // Pick the most recently uploaded file that wasn't deleted yet.
+
+    for (
+      let rootId = await pdpVerifier.getNextRootId(proofSetId) - 1n;
+      rootId >= 0n;
+      rootId--
+    ) {
+      console.log('Checking root ID:', rootId)
+      const rootIsLive = await pdpVerifier.rootLive(proofSetId, rootId)
+      if (!rootIsLive) {
+        console.log('Root is not live')
+        continue
+      }
+
+      const [rootCidRaw] = await pdpVerifier.getRootCid(proofSetId, rootId)
+      console.log('Found CommP:', rootCidRaw)
+      const cidBytes = Buffer.from(rootCidRaw.slice(2), 'hex')
+      const rootCidObj = CID.decode(cidBytes)
+      console.log('Converted to CommP CID:', rootCidObj)
+      const rootCid = rootCidObj.toString()
+
+      if (IGNORED_ROOTS.includes(`${proofSetId}:${rootCid}`)) {
+        console.log('We are ignoring this root')
+        continue
+      }
+
+      return { rootCid, proofSetId, rootId, clientAddress }
+    }
+  }
+
+  throw new Error('No suitable root found')
+}

--- a/index.js
+++ b/index.js
@@ -360,17 +360,20 @@ async function pickRandomFileWithCDN({
  * @param {PdpVerifier} args.pdpVerifier
  * @param {PandoraService} args.pandoraService
  * @param {string} args.CDN_HOSTNAME
+ * @param {BigInt} args.FROM_PROOFSET_ID
  */
 
 export async function testLatestRetrievableRoot({
   pdpVerifier,
   pandoraService,
   CDN_HOSTNAME,
+  FROM_PROOFSET_ID,
 }) {
   const { rootCid, proofSetId, rootId, clientAddress } =
     await getMostRecentFileWithCDN({
       pdpVerifier,
       pandoraService,
+      FROM_PROOFSET_ID,
     })
 
   await testRetrieval({
@@ -388,6 +391,7 @@ export async function testLatestRetrievableRoot({
  * @param {Object} args
  * @param {PdpVerifier} args.pdpVerifier
  * @param {PandoraService} args.pandoraService
+ * @param {BigInt} args.FROM_PROOFSET_ID
  * @returns {Promise<{
  *   rootCid: string
  *   proofSetId: BigInt
@@ -396,10 +400,14 @@ export async function testLatestRetrievableRoot({
  * }>}
  *   The CommP CID of the file.
  */
-async function getMostRecentFileWithCDN({ pdpVerifier, pandoraService }) {
+async function getMostRecentFileWithCDN({
+  pdpVerifier,
+  pandoraService,
+  FROM_PROOFSET_ID,
+}) {
   for (
     let proofSetId = (await pdpVerifier.getNextProofSetId()) - 1n;
-    proofSetId >= 0n;
+    proofSetId >= 0n && proofSetId >= FROM_PROOFSET_ID;
     proofSetId--
   ) {
     console.log('Checking proof set ID:', proofSetId)

--- a/index.js
+++ b/index.js
@@ -365,14 +365,13 @@ async function pickRandomFileWithCDN({
 export async function testLatestRetrievableRoot({
   pdpVerifier,
   pandoraService,
-  CDN_HOSTNAME
+  CDN_HOSTNAME,
 }) {
-  const { rootCid, proofSetId, rootId, clientAddress } = await getMostRecentFileWithCDN(
-    {
+  const { rootCid, proofSetId, rootId, clientAddress } =
+    await getMostRecentFileWithCDN({
       pdpVerifier,
-      pandoraService
-    },
-  )
+      pandoraService,
+    })
 
   await testRetrieval({
     pdpVerifier,
@@ -397,10 +396,7 @@ export async function testLatestRetrievableRoot({
  * }>}
  *   The CommP CID of the file.
  */
-async function getMostRecentFileWithCDN({
-  pdpVerifier,
-  pandoraService
-}) {
+async function getMostRecentFileWithCDN({ pdpVerifier, pandoraService }) {
   for (
     let proofSetId = (await pdpVerifier.getNextProofSetId()) - 1n;
     proofSetId >= 0n;
@@ -418,9 +414,7 @@ async function getMostRecentFileWithCDN({
     const { withCDN, payer: clientAddress, payee: providerAddress } = info
 
     if (!withCDN) {
-      console.log(
-        'Proof set does not pay for CDN',
-      )
+      console.log('Proof set does not pay for CDN')
       continue
     }
 
@@ -436,7 +430,7 @@ async function getMostRecentFileWithCDN({
     // Pick the most recently uploaded file that wasn't deleted yet.
 
     for (
-      let rootId = await pdpVerifier.getNextRootId(proofSetId) - 1n;
+      let rootId = (await pdpVerifier.getNextRootId(proofSetId)) - 1n;
       rootId >= 0n;
       rootId--
     ) {


### PR DESCRIPTION
Closes filcdn/roadmap#4

I decided to reduce scope and simply add a second loop that tests retrieval of the most recent retrievable root. If it isn't retrievable, it will create an #alert. We can iterate from there if needed.