### PR TITLE
fix: suppress alerts on 421 errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,12 @@ const IGNORED_ROOTS = [
   '442:baga6ea4seaqnbpfza3wl5fgu7gnfcyh5h6zufn4skwt6clylnzaw5k6maiwt6ay',
 ]
 
+// HTTP response status codes that are not actionable for us and we don't want to alert on them
+const NO_ALERT_ON_RESPONSE_STATUS_CODES = [
+  // Error 521 occurs when the origin web server refuses connections from Cloudflare.
+  521,
+]
+
 export const pdpVerifierAbi = [
   // Returns the next proof set ID
   'function getNextProofSetId() public view returns (uint64)',
@@ -141,6 +147,11 @@ async function testRetrieval({
         rootId,
         retryOn404: false,
       })
+    }
+
+    if (NO_ALERT_ON_RESPONSE_STATUS_CODES.includes(res.status)) {
+      console.log('This error is not actionable for us, suppressing the alert.')
+      return
     }
 
     const proofSetIdHeaderValue = res.headers.get('x-proof-set-id')


### PR DESCRIPTION
Error 521 occurs when the origin web server refuses connections from Cloudflare, see
https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-521/
