### PR TITLE
Add support for retrieval of PDP pieces without CDN enabled

### DIFF
--- a/bin/bot.js
+++ b/bin/bot.js
@@ -45,6 +45,7 @@ await Promise.all([
         botLocation: FLY_REGION,
         CDN_HOSTNAME,
         FROM_PROOFSET_ID: BigInt(FROM_PROOFSET_ID),
+        withCDN: true,
       })
       console.log('\n')
       await setTimeout(Number(DELAY))
@@ -58,6 +59,7 @@ await Promise.all([
         botLocation: FLY_REGION,
         CDN_HOSTNAME,
         FROM_PROOFSET_ID: BigInt(FROM_PROOFSET_ID),
+        withCDN: true,
       })
       console.log('\n')
       await setTimeout(Number(30_000)) // block time


### PR DESCRIPTION
Add support for retrieval of pieces from PDP data sets that don't have `withCDN` flag enabled. 