### PR TITLE
Update ABI interfaces used by retrieval bot

### DIFF
--- a/bin/bot.js
+++ b/bin/bot.js
@@ -35,11 +35,7 @@ const pdpVerifier = /** @type {any} */ (
 
 /** @type {import('../index.js').FilecoinWarmStorageServiceStateView} */
 const fwssStateView = /** @type {any} */ (
-  new ethers.Contract(
-    FWSS_STATE_VIEW_ADDRESS,
-    fwssStateViewAbi,
-    provider,
-  )
+  new ethers.Contract(FWSS_STATE_VIEW_ADDRESS, fwssStateViewAbi, provider)
 )
 
 /** @type {import('../index.js').ServiceProviderRegistry} */

--- a/bin/bot.js
+++ b/bin/bot.js
@@ -1,7 +1,7 @@
 import { setTimeout } from 'node:timers/promises'
 import { ethers } from 'ethers'
 import {
-  filecoinWarmStorageServiceStateViewStateViewAbi,
+  fwssStateViewAbi,
   serviceProviderRegistryAbi,
   pdpVerifierAbi,
   sampleRetrieval,
@@ -13,7 +13,7 @@ const {
   GLIF_TOKEN,
   RPC_URL = 'https://api.calibration.node.glif.io/',
   PDP_VERIFIER_ADDRESS = '0x445238Eca6c6aB8Dff1Aa6087d9c05734D22f137',
-  FILECOIN_WARM_STORAGE_SERVICE_STATE_VIEW_ADDRESS = '0x87EDE87cEF4BfeFE0374c3470cB3F5be18b739d5',
+  FWSS_STATE_VIEW_ADDRESS = '0x87EDE87cEF4BfeFE0374c3470cB3F5be18b739d5',
   SERVICE_PROVIDER_REGISTRY_ADDRESS = '0xA8a7e2130C27e4f39D1aEBb3D538D5937bCf8ddb',
   CDN_HOSTNAME = 'calibration.filcdn.io',
   DELAY = 1_000,
@@ -34,10 +34,10 @@ const pdpVerifier = /** @type {any} */ (
 )
 
 /** @type {import('../index.js').FilecoinWarmStorageServiceStateView} */
-const filecoinWarmStorageServiceStateView = /** @type {any} */ (
+const fwssStateView = /** @type {any} */ (
   new ethers.Contract(
-    FILECOIN_WARM_STORAGE_SERVICE_STATE_VIEW_ADDRESS,
-    filecoinWarmStorageServiceStateViewStateViewAbi,
+    FWSS_STATE_VIEW_ADDRESS,
+    fwssStateViewAbi,
     provider,
   )
 )
@@ -56,7 +56,7 @@ await Promise.all([
     while (true) {
       await sampleRetrieval({
         pdpVerifier,
-        filecoinWarmStorageServiceStateView,
+        fwssStateView,
         serviceProviderRegistry,
         botLocation: FLY_REGION,
         CDN_HOSTNAME,
@@ -70,7 +70,7 @@ await Promise.all([
     while (true) {
       await testLatestRetrievablePiece({
         pdpVerifier,
-        filecoinWarmStorageServiceStateView,
+        fwssStateView,
         serviceProviderRegistry,
         botLocation: FLY_REGION,
         CDN_HOSTNAME,

--- a/bin/bot.js
+++ b/bin/bot.js
@@ -1,7 +1,7 @@
 import { setTimeout } from 'node:timers/promises'
 import { ethers } from 'ethers'
 import {
-  filecoinWarmStorageServiceAbi,
+  filecoinWarmStorageServiceStateViewStateViewAbi,
   serviceProviderRegistryAbi,
   pdpVerifierAbi,
   sampleRetrieval,
@@ -13,9 +13,9 @@ const {
   GLIF_TOKEN,
   RPC_URL = 'https://api.calibration.node.glif.io/',
   PDP_VERIFIER_PROXY_ADDRESS = '0xf9f521c6e11A1680ead3eDD8a2757Ea731458617',
-  FILECOIN_WARM_STORAGE_SERVICE_PROXY_ADDRESS = '0xfa564144f183E4E7B8FEdCfbAa412afc83D5aE3d',
   // TODO: replace with the actual address
-  SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS = '0x',
+  FILECOIN_WARM_STORAGE_SERVICE_STATE_VIEW_ADDRESS = '0x',
+  SERVICE_PROVIDER_REGISTRY_ADDRESS = '0x',
   CDN_HOSTNAME = 'calibration.filcdn.io',
   DELAY = 1_000,
   FROM_DATASET_ID = 0,
@@ -34,11 +34,11 @@ const pdpVerifier = /** @type {any} */ (
   new ethers.Contract(PDP_VERIFIER_PROXY_ADDRESS, pdpVerifierAbi, provider)
 )
 
-/** @type {import('../index.js').FilecoinWarmStorageService} */
-const filecoinWarmStorageService = /** @type {any} */ (
+/** @type {import('../index.js').FilecoinWarmStorageServiceStateView} */
+const filecoinWarmStorageServiceStateView = /** @type {any} */ (
   new ethers.Contract(
-    FILECOIN_WARM_STORAGE_SERVICE_PROXY_ADDRESS,
-    filecoinWarmStorageServiceAbi,
+    FILECOIN_WARM_STORAGE_SERVICE_STATE_VIEW_ADDRESS,
+    filecoinWarmStorageServiceStateViewStateViewAbi,
     provider,
   )
 )
@@ -46,7 +46,7 @@ const filecoinWarmStorageService = /** @type {any} */ (
 /** @type {import('../index.js').ServiceProviderRegistry} */
 const serviceProviderRegistry = /** @type {any} */ (
   new ethers.Contract(
-    SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS,
+    SERVICE_PROVIDER_REGISTRY_ADDRESS,
     serviceProviderRegistryAbi,
     provider,
   )
@@ -57,7 +57,7 @@ await Promise.all([
     while (true) {
       await sampleRetrieval({
         pdpVerifier,
-        filecoinWarmStorageService,
+        filecoinWarmStorageServiceStateView,
         serviceProviderRegistry,
         botLocation: FLY_REGION,
         CDN_HOSTNAME,
@@ -71,7 +71,7 @@ await Promise.all([
     while (true) {
       await testLatestRetrievablePiece({
         pdpVerifier,
-        filecoinWarmStorageService,
+        filecoinWarmStorageServiceStateView,
         serviceProviderRegistry,
         botLocation: FLY_REGION,
         CDN_HOSTNAME,

--- a/bin/bot.js
+++ b/bin/bot.js
@@ -12,10 +12,9 @@ const {
   FLY_REGION,
   GLIF_TOKEN,
   RPC_URL = 'https://api.calibration.node.glif.io/',
-  PDP_VERIFIER_PROXY_ADDRESS = '0xf9f521c6e11A1680ead3eDD8a2757Ea731458617',
-  // TODO: replace with the actual address
-  FILECOIN_WARM_STORAGE_SERVICE_STATE_VIEW_ADDRESS = '0x',
-  SERVICE_PROVIDER_REGISTRY_ADDRESS = '0x',
+  PDP_VERIFIER_ADDRESS = '0x445238Eca6c6aB8Dff1Aa6087d9c05734D22f137',
+  FILECOIN_WARM_STORAGE_SERVICE_STATE_VIEW_ADDRESS = '0x87EDE87cEF4BfeFE0374c3470cB3F5be18b739d5',
+  SERVICE_PROVIDER_REGISTRY_ADDRESS = '0xA8a7e2130C27e4f39D1aEBb3D538D5937bCf8ddb',
   CDN_HOSTNAME = 'calibration.filcdn.io',
   DELAY = 1_000,
   FROM_DATA_SET_ID = 0,
@@ -31,7 +30,7 @@ const provider = new ethers.JsonRpcProvider(fetchRequest, undefined, {
 
 /** @type {import('../index.js').PdpVerifier} */
 const pdpVerifier = /** @type {any} */ (
-  new ethers.Contract(PDP_VERIFIER_PROXY_ADDRESS, pdpVerifierAbi, provider)
+  new ethers.Contract(PDP_VERIFIER_ADDRESS, pdpVerifierAbi, provider)
 )
 
 /** @type {import('../index.js').FilecoinWarmStorageServiceStateView} */

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ export const pdpVerifierAbi = [
  * }} PdpVerifier
  */
 
-export const filecoinWarmStorageServiceStateViewStateViewAbi = [
+export const fwssStateViewAbi = [
   `function getDataSet(uint256 dataSetId) external view returns (tuple(
     uint256 pdpRailId,
     uint256 cacheMissRailId,
@@ -125,7 +125,7 @@ export const serviceProviderRegistryAbi = [
 /**
  * @param {object} args
  * @param {PdpVerifier} args.pdpVerifier
- * @param {FilecoinWarmStorageServiceStateView} args.filecoinWarmStorageServiceStateView
+ * @param {FilecoinWarmStorageServiceStateView} args.fwssStateView
  * @param {ServiceProviderRegistry} args.serviceProviderRegistry
  * @param {string} args.clientAddress
  * @param {string} [args.botLocation] Fly region where the bot is running
@@ -139,7 +139,7 @@ export const serviceProviderRegistryAbi = [
  */
 async function testRetrieval({
   pdpVerifier,
-  filecoinWarmStorageServiceStateView,
+  fwssStateView,
   serviceProviderRegistry,
   clientAddress,
   botLocation,
@@ -165,7 +165,7 @@ async function testRetrieval({
       await new Promise((resolve) => setTimeout(resolve, retryDelayMs))
       return testRetrieval({
         serviceProviderRegistry,
-        filecoinWarmStorageServiceStateView,
+        fwssStateView,
         pdpVerifier,
         clientAddress,
         botLocation,
@@ -185,7 +185,7 @@ async function testRetrieval({
     const dataSetIdHeaderValue = res.headers.get('x-data-set-id')
     const pieceRetrievalUrl = await maybeGetResolvedDataSetRetrievalUrl({
       pdpVerifier,
-      filecoinWarmStorageServiceStateView,
+      fwssStateView,
       serviceProviderRegistry,
       dataSetIdHeaderValue,
     })
@@ -215,14 +215,14 @@ async function testRetrieval({
 /**
  * @param {object} args
  * @param {PdpVerifier} args.pdpVerifier
- * @param {FilecoinWarmStorageServiceStateView} args.filecoinWarmStorageServiceStateView
+ * @param {FilecoinWarmStorageServiceStateView} args.fwssStateView
  * @param {ServiceProviderRegistry} args.serviceProviderRegistry
  * @param {string | null} args.dataSetIdHeaderValue
  * @returns {Promise<string | undefined>} The piece retrieval URL
  */
 async function maybeGetResolvedDataSetRetrievalUrl({
   pdpVerifier,
-  filecoinWarmStorageServiceStateView,
+  fwssStateView,
   serviceProviderRegistry,
   dataSetIdHeaderValue,
 }) {
@@ -248,7 +248,7 @@ async function maybeGetResolvedDataSetRetrievalUrl({
       await serviceProviderRegistry.getProviderIdByAddress(dataSetOwner)
 
     const isApprovedProvider =
-      await filecoinWarmStorageServiceStateView.isProviderApproved(providerId)
+      await fwssStateView.isProviderApproved(providerId)
     if (!isApprovedProvider) {
       console.warn(
         'Provider %s for DataSetID %s is not approved, skipping retrieval URL resolution',
@@ -283,7 +283,7 @@ async function maybeGetResolvedDataSetRetrievalUrl({
 /**
  * @param {object} args
  * @param {PdpVerifier} args.pdpVerifier
- * @param {FilecoinWarmStorageServiceStateView} args.filecoinWarmStorageServiceStateView
+ * @param {FilecoinWarmStorageServiceStateView} args.fwssStateView
  * @param {ServiceProviderRegistry} args.serviceProviderRegistry
  * @param {string} [args.botLocation] Fly region where the bot is running
  * @param {string} args.CDN_HOSTNAME
@@ -292,7 +292,7 @@ async function maybeGetResolvedDataSetRetrievalUrl({
 
 export async function sampleRetrieval({
   pdpVerifier,
-  filecoinWarmStorageServiceStateView,
+  fwssStateView,
   serviceProviderRegistry,
   botLocation = '<dev>',
   CDN_HOSTNAME,
@@ -301,14 +301,14 @@ export async function sampleRetrieval({
   const { pieceCid, dataSetId, pieceId, clientAddress } =
     await pickRandomFileWithCDN({
       pdpVerifier,
-      filecoinWarmStorageServiceStateView,
+      fwssStateView,
       serviceProviderRegistry,
       FROM_DATA_SET_ID,
     })
 
   await testRetrieval({
     pdpVerifier,
-    filecoinWarmStorageServiceStateView,
+    fwssStateView,
     serviceProviderRegistry,
     clientAddress,
     botLocation,
@@ -322,7 +322,7 @@ export async function sampleRetrieval({
 /**
  * @param {Object} args
  * @param {PdpVerifier} args.pdpVerifier
- * @param {FilecoinWarmStorageServiceStateView} args.filecoinWarmStorageServiceStateView
+ * @param {FilecoinWarmStorageServiceStateView} args.fwssStateView
  * @param {ServiceProviderRegistry} args.serviceProviderRegistry
  * @param {BigInt} args.FROM_DATA_SET_ID
  * @returns {Promise<{
@@ -335,7 +335,7 @@ export async function sampleRetrieval({
  */
 async function pickRandomFileWithCDN({
   pdpVerifier,
-  filecoinWarmStorageServiceStateView,
+  fwssStateView,
   serviceProviderRegistry,
   FROM_DATA_SET_ID,
 }) {
@@ -368,11 +368,11 @@ async function pickRandomFileWithCDN({
 
     const dataSet =
       cachedDataSetsInfo.get(dataSetId) ??
-      (await filecoinWarmStorageServiceStateView.getDataSet(dataSetId))
+      (await fwssStateView.getDataSet(dataSetId))
     cachedDataSetsInfo.set(dataSetId, dataSet)
     const { payer: clientAddress, payee: providerAddress } = dataSet
     const { exists: withCDN } =
-      await filecoinWarmStorageServiceStateView.getDataSetMetadata(
+      await fwssStateView.getDataSetMetadata(
         dataSetId,
         'withCDN',
       )
@@ -388,7 +388,7 @@ async function pickRandomFileWithCDN({
       await serviceProviderRegistry.getProviderIdByAddress(providerAddress)
 
     const isApprovedProvider =
-      await filecoinWarmStorageServiceStateView.isProviderApproved(providerId)
+      await fwssStateView.isProviderApproved(providerId)
     if (!isApprovedProvider) {
       console.log('Provider is not approved, restarting the sampling algorithm')
       continue
@@ -448,7 +448,7 @@ async function pickRandomFileWithCDN({
 /**
  * @param {object} args
  * @param {PdpVerifier} args.pdpVerifier
- * @param {FilecoinWarmStorageServiceStateView} args.filecoinWarmStorageServiceStateView
+ * @param {FilecoinWarmStorageServiceStateView} args.fwssStateView
  * @param {ServiceProviderRegistry} args.serviceProviderRegistry
  * @param {string} [args.botLocation] Fly region where the bot is running
  * @param {string} args.CDN_HOSTNAME
@@ -457,7 +457,7 @@ async function pickRandomFileWithCDN({
 
 export async function testLatestRetrievablePiece({
   pdpVerifier,
-  filecoinWarmStorageServiceStateView,
+  fwssStateView,
   serviceProviderRegistry,
   botLocation,
   CDN_HOSTNAME,
@@ -466,14 +466,14 @@ export async function testLatestRetrievablePiece({
   const { pieceCid, dataSetId, pieceId, clientAddress } =
     await getMostRecentFileWithCDN({
       pdpVerifier,
-      filecoinWarmStorageServiceStateView,
+      fwssStateView,
       serviceProviderRegistry,
       FROM_DATA_SET_ID,
     })
 
   await testRetrieval({
     pdpVerifier,
-    filecoinWarmStorageServiceStateView,
+    fwssStateView,
     serviceProviderRegistry,
     clientAddress,
     botLocation,
@@ -487,7 +487,7 @@ export async function testLatestRetrievablePiece({
 /**
  * @param {Object} args
  * @param {PdpVerifier} args.pdpVerifier
- * @param {FilecoinWarmStorageServiceStateView} args.filecoinWarmStorageServiceStateView
+ * @param {FilecoinWarmStorageServiceStateView} args.fwssStateView
  * @param {ServiceProviderRegistry} args.serviceProviderRegistry
  * @param {BigInt} args.FROM_DATA_SET_ID
  * @returns {Promise<{
@@ -500,7 +500,7 @@ export async function testLatestRetrievablePiece({
  */
 async function getMostRecentFileWithCDN({
   pdpVerifier,
-  filecoinWarmStorageServiceStateView,
+  fwssStateView,
   serviceProviderRegistry,
   FROM_DATA_SET_ID,
 }) {
@@ -518,11 +518,11 @@ async function getMostRecentFileWithCDN({
     }
 
     const { payer: clientAddress, payee: providerAddress } =
-      await filecoinWarmStorageServiceStateView.getDataSet(dataSetId)
+      await fwssStateView.getDataSet(dataSetId)
     
     // If `withCDN` metadata key is present it means the data set pays for CDN
     const { exists: withCDN } =
-      await filecoinWarmStorageServiceStateView.getDataSetMetadata(
+      await fwssStateView.getDataSetMetadata(
         dataSetId,
         'withCDN',
       )
@@ -535,7 +535,7 @@ async function getMostRecentFileWithCDN({
     const providerId =
       await serviceProviderRegistry.getProviderIdByAddress(providerAddress)
     const isApprovedProvider =
-      await filecoinWarmStorageServiceStateView.isProviderApproved(providerId)
+      await fwssStateView.isProviderApproved(providerId)
     if (!isApprovedProvider) {
       console.log('Provider is not approved, restarting the sampling algorithm')
       continue

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ export const fwssStateViewAbi = [
     uint256 paymentEndEpoch,
   ) memory)`,
   `function getDataSetMetadata(uint256 dataSetId, string memory key) external view returns (bool exists, string memory value)`,
-  'function isProviderApproved(uint256 providerId) external view returns (bool)'
+  'function isProviderApproved(uint256 providerId) external view returns (bool)',
 ]
 
 export const serviceProviderRegistryAbi = [
@@ -371,11 +371,10 @@ async function pickRandomFileWithCDN({
       (await fwssStateView.getDataSet(dataSetId))
     cachedDataSetsInfo.set(dataSetId, dataSet)
     const { payer: clientAddress, payee: providerAddress } = dataSet
-    const { exists: withCDN } =
-      await fwssStateView.getDataSetMetadata(
-        dataSetId,
-        'withCDN',
-      )
+    const { exists: withCDN } = await fwssStateView.getDataSetMetadata(
+      dataSetId,
+      'withCDN',
+    )
 
     if (!withCDN) {
       console.log(
@@ -519,13 +518,12 @@ async function getMostRecentFileWithCDN({
 
     const { payer: clientAddress, payee: providerAddress } =
       await fwssStateView.getDataSet(dataSetId)
-    
+
     // If `withCDN` metadata key is present it means the data set pays for CDN
-    const { exists: withCDN } =
-      await fwssStateView.getDataSetMetadata(
-        dataSetId,
-        'withCDN',
-      )
+    const { exists: withCDN } = await fwssStateView.getDataSetMetadata(
+      dataSetId,
+      'withCDN',
+    )
 
     if (!withCDN) {
       console.log('data set does not pay for CDN')

--- a/index.js
+++ b/index.js
@@ -251,7 +251,7 @@ async function maybeGetResolvedDataSetRetrievalUrl({
       await fwssStateView.isProviderApproved(providerId)
     if (!isApprovedProvider) {
       console.warn(
-        'Provider %s for DataSetID %s is not approved, skipping retrieval URL resolution',
+        'Provider %s for data set ID %s is not approved, skipping retrieval URL resolution',
         dataSetId,
         dataSetOwner,
       )

--- a/index.js
+++ b/index.js
@@ -50,13 +50,13 @@ export const filecoinWarmStorageServiceStateViewStateViewAbi = [
     uint256 paymentEndEpoch,
   ) memory)`,
   `function getDataSetMetadata(uint256 dataSetId, string memory key) external view returns (bool exists, string memory value)`,
-  `function isProviderApproved(address provider) external view returns (bool)`,
+  'function isProviderApproved(uint256 providerId) external view returns (bool)'
 ]
 
 export const serviceProviderRegistryAbi = [
-  'function getProviderByAddress(address provider) external view returns (uint256)',
   'function getPDPService(uint256 providerId) external view returns (tuple(tuple(string,uint256,uint256,bool,bool,uint256,uint256,string,address), string[] capabilityKeys, bool isActive) memory)',
   'function getProviderIdByAddress(address provider) external view returns (uint256)',
+  'function isProviderActive(uint256 providerId) external view returns (bool)',
 ]
 
 /**
@@ -371,12 +371,11 @@ async function pickRandomFileWithCDN({
       (await filecoinWarmStorageServiceStateView.getDataSet(dataSetId))
     cachedDataSetsInfo.set(dataSetId, dataSet)
     const { payer: clientAddress, payee: providerAddress } = dataSet
-    const { exists: withCDNMetadaKeyExists, value: withCDNMetadataValue } =
+    const { exists: withCDN } =
       await filecoinWarmStorageServiceStateView.getDataSetMetadata(
         dataSetId,
         'withCDN',
       )
-    const withCDN = withCDNMetadaKeyExists && withCDNMetadataValue === 'true'
 
     if (!withCDN) {
       console.log(
@@ -520,12 +519,13 @@ async function getMostRecentFileWithCDN({
 
     const { payer: clientAddress, payee: providerAddress } =
       await filecoinWarmStorageServiceStateView.getDataSet(dataSetId)
-    const { exists: withCDNMetadaKeyExists, value: withCDNMetadataValue } =
+    
+    // If `withCDN` metadata key is present it means the data set pays for CDN
+    const { exists: withCDN } =
       await filecoinWarmStorageServiceStateView.getDataSetMetadata(
         dataSetId,
         'withCDN',
       )
-    const withCDN = withCDNMetadaKeyExists && withCDNMetadataValue === 'true'
 
     if (!withCDN) {
       console.log('data set does not pay for CDN')

--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ async function testRetrieval({
     })
 
     console.error(
-      'ALERT Cannot retrieve DataSet %s Piece %s (resolved as DataSet %s from SP %s) from %s via %s: %s %s',
+      'ALERT Cannot retrieve data set %s piece %s (resolved as data set %s from SP %s) from %s via %s: %s %s',
       String(dataSetId),
       String(pieceId),
       dataSetIdHeaderValue ?? '<not reported>',


### PR DESCRIPTION
- Rename PandoraService to FilecoinWarmStorageService
- Update renamed terms (proofSet -> dataSet, root -> piece, etc.)
- Update ABI interfaces for FilecoinWarmStorageService, PDPVerifier contracts
- Add ServiceProviderRegistry contract ABI and use ServiceProviderRegistry to fetch provider info
- Update code according to updated ABI interfaces
- Use metadata k/v pairs to check if data set has CDN enabled 
- Update contract addresses to proxy addresses
- Restart `FROM_DATASET_ID` 
- Remove ignored pieces

Close https://github.com/filcdn/bot/issues/25